### PR TITLE
Hotfix for cfgbus python handling reply = None and callbacks.

### DIFF
--- a/src/python/satcat5_cfgbus.py
+++ b/src/python/satcat5_cfgbus.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2021 The Aerospace Corporation
+# Copyright 2021, 2022 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #


### PR DESCRIPTION
<!--- Provide a brief summary of your changes in the Title above -->
 Fixed reply = None and ConfigBus callback

## Description
<!--- Describe your changes in detail -->
- The hotfix corrects checking the length of 'None'.  
- Changed scope of certain 'reply' variables to 'self.reply'
- Fixed the callback initialization.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Hotfix corrects errors when the ConfigBus does not receive a reply, as well as when the callback is called.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
