### PR TITLE
PR-19 hotfix: Simplify build process and update ARTY_A7 readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2019, 2021, 2022 The Aerospace Corporation
+# Copyright 2019, 2021, 2022, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -20,8 +20,13 @@
 *.o
 
 # Ignore temporary files (Vim, etc.)
+~*
+*.jou
+*.log
 *.swp
 *.swo
+backups
+build_tmp
 .vscode/settings.json
 .vscode/settings.json
 
@@ -40,8 +45,32 @@ project/icecube2_2017.8/**
 !project/icecube2_2017.8/*/*.pcf
 !project/icecube2_2017.8/*/*.sdc
 
-# Ignore all libero-created subfolders
+# Ignore all Libero-created subfolders
 project/libero/*/
 
-# Ignore all yosys-created subfolders
+# Ignore all Modelsim-created subfolders
+project/modelsim/*.ini
+project/modelsim/*.mti
+project/modelsim/*.mpf
+project/modelsim/*.wlf
+project/modelsim/work
+
+# Ignore all Vivado-created subfolders
+*.bit
+*.cache
+*.dmp
+*.hdf
+*.hw
+*.ip_user_files
+*.metadata
+*.project
+*.runs
+*.srcs
+.Xil
+examples/*/*/*.xdc
+satcat5_ip
+sdk_hw
+sdk_bsp
+
+# Ignore all Yosys-created subfolders
 project/yosys/*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020, 2021, 2022 The Aerospace Corporation
+# Copyright 2020, 2021, 2022, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -30,7 +30,6 @@ export VIVADO_VERSION := ${VIVADO_VERSION}
 VIVADO_SETUP := source /opt/Xilinx/Vivado/${VIVADO_VERSION}/settings64.sh
 VIVADO_BATCH := vivado -mode batch -nojournal -nolog -notrace -source
 VIVADO_RUN := ${VIVADO_SETUP} && xvfb-run -a ${VIVADO_BATCH}
-VIVADO_BUILD := ${VIVADO_RUN} ../../project/vivado/build_project.tcl -tclargs
 
 # Software analysis parameters
 CPPCHECK_RUN := cppcheck \
@@ -57,34 +56,28 @@ sims:
 .PHONY: proto_v1_base
 proto_v1_base:
 	@cd examples/ac701_proto_v1 && ${VIVADO_RUN} create_project_proto_v1_base.tcl
-	@cd examples/ac701_proto_v1 && ${VIVADO_BUILD} switch_proto_v1_base
 
 .PHONY: proto_v1_rgmii
 proto_v1_rgmii:
 	@cd examples/ac701_proto_v1 && ${VIVADO_RUN} create_project_proto_v1_rgmii.tcl
-	@cd examples/ac701_proto_v1 && ${VIVADO_BUILD} switch_proto_v1_rgmii
 
 .PHONY: proto_v1_sgmii
 proto_v1_sgmii:
 	@cd examples/ac701_proto_v1 && ${VIVADO_RUN} create_project_proto_v1_sgmii.tcl
-	@cd examples/ac701_proto_v1 && ${VIVADO_BUILD} switch_proto_v1_sgmii
 
 # 2nd-gen prototype using integrated custom PCB
 .PHONY: proto_v2
 proto_v2:
 	@cd examples/proto_v2 && ${VIVADO_RUN} create_project_proto_v2.tcl
-	@cd examples/proto_v2 && ${VIVADO_BUILD} switch_proto_v2
 
 # Arty-A7 example design (Artix7-35T or Artix7-100T)
 .PHONY: arty_35t
 arty_35t:
 	@cd examples/arty_a7 && ${VIVADO_RUN} create_project_arty_a7.tcl -tclargs 35T
-	@cd examples/arty_a7 && ${VIVADO_BUILD} switch_arty_a7_35t
 
 .PHONY: arty_100t
 arty_100t:
 	@cd examples/arty_a7 && ${VIVADO_RUN} create_project_arty_a7.tcl -tclargs 100T
-	@cd examples/arty_a7 && ${VIVADO_BUILD} switch_arty_a7_100t
 
 .PHONY: arty_managed_35t
 arty_managed_35t:
@@ -98,7 +91,6 @@ arty_managed_100t:
 .PHONY: ac701_router
 ac701_router:
 	@cd examples/ac701_router && ${VIVADO_RUN} create_project_router_ac701.tcl
-	@cd examples/ac701_router && ${VIVADO_BUILD} router_ac701
 
 # NetFPGA example design
 .PHONY: netfpga
@@ -118,7 +110,6 @@ vc707_managed:
 .PHONY: zed_converter
 zed_converter:
 	@cd examples/zed_converter && ${VIVADO_RUN} create_project_converter_zed.tcl
-	@cd examples/zed_converter && ${VIVADO_BUILD} converter_zed
 
 # Example design for MPF splash kit
 .PHONY: mpf_splash

--- a/doc/ARTY_A7.md
+++ b/doc/ARTY_A7.md
@@ -5,28 +5,33 @@
 
 # Overview
 
-We provide an example design for the [Digilent Arty A7 board](https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start) that can be used with the Python chat app or your own code to try out SatCat5.
+We provide an example design for the
+[Digilent Arty A7 board](https://reference.digilentinc.com/reference/programmable-logic/arty-a7/start)
+that can be used with the Python chat app or your own code to try out SatCat5.
 
-The design provides four UART ports on the PMOD connectors, one 10/100Mbps ethernet port connected to the FPGA MAC over RMII, and a status LCD interface on the ChipKit IOs.
+The design provides four UART ports on the PMOD connectors, one 10/100Mbps Ethernet port
+connected to the FPGA MAC over RMII, and a status LCD interface on the ChipKit IOs.
 
 
 # Building
 
-The design has been tested on both Arty A7 35T and 100T variants with Vivado 2015.4, 2018.2, or 2018.3.
+The design has been tested on both Arty A7 35T and 100T variants with Vivado 2015.4, 2016.1, 2018.2, 2018.3, or 2019.1.
 Follow these steps to build the design and deploy to your Arty A7 board.
 
-1. Obtain and install [Digilent board files](https://reference.digilentinc.com/vivado/installing-vivado/start) for Vivado
-1. From `project/vivado_2015.4` create and build the project with either of the methods below (examples for 100T variant).
-    * From the terminal, run
+1. Obtain and install [Digilent board files](https://reference.digilentinc.com/vivado/installing-vivado/start) for Vivado.
+1. Launch the Vivado GUI.
+1. From the Vivado TCL shell:
+    * Navigate to the SatCat5 folder. e.g., `cd path/to/satcat5`
+    * Run either `set argv 35t` or `set argv 100t` to select the appropriate hardware variant.
+    * Then run the following commands:
         ```
-        vivado -mode batch -nojournal -nolog -notrace -source create_project_arty_a7.tcl -tclargs 100T
-        vivado -mode batch -nojournal -nolog -notrace -source build_arty_a7_rmii.tcl -tclargs 100T
+        cd examples/arty_a7
+        source create_project_arty_a7.tcl
         ```
-    * From the Vivado GUI, run `set argv 100T` then `source ./create_project_arty_a7.tcl` and use the GUI to generate the bitstream.
 1. Connect an ethernet cable and up to 4 USB-UART cables (or Digilent PMOD USB-UART adapters) to the board and PC.
 If using 2-wire UART tie the `CTSb` line (pin 1) of each port to ground (pin 5).
 1. Open jumper JP1 to load bitstream with JTAG and program the device in Vivado.
-The `.bin` files generated in `project/vivado_2015.4/backups` can also be used to program the SPI flash.
+The `.bin` files generated in `examples/arty_a7/backups` can also be used to program the SPI flash.
 
 ## Notes
 * When using a design stored on the SPI flash, you may need to press the reset button after powering the board if power is applied through the micro-USB header.
@@ -38,13 +43,13 @@ The `.bin` files generated in `project/vivado_2015.4/backups` can also be used t
 1. Enjoy testing SatCat5 performance!
 
 ## Notes
-* The UART ports are fixed at 921,600 baud by default in the example design and the ethernet link operates at 100Mbps unless forced to 10Mbps by lowering `GPO_RMII_FAST` in `swtich_cfg.py`.
+* The UART ports are fixed at 921,600 baud by default in the example design and the ethernet link operates at 100Mbps unless forced to 10Mbps by lowering `GPO_RMII_FAST` in `switch_cfg.py`.
 * The `RESET` button may be pressed to reset the switch logic and ethernet PHY without reloading device configuration.
 
 
 # Copyright Notice
 
-Copyright 2019 The Aerospace Corporation
+Copyright 2019, 2023 The Aerospace Corporation
 
 This file is part of SatCat5.
 

--- a/examples/ac701_proto_v1/create_project_proto_v1_base.tcl
+++ b/examples/ac701_proto_v1/create_project_proto_v1_base.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2020, 2021 The Aerospace Corporation
+# Copyright 2019, 2020, 2021, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -42,3 +42,8 @@ set files_main [list \
 
 # Run the main script.
 source ../../project/vivado/shared_create.tcl
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin $target_top.bin

--- a/examples/ac701_proto_v1/create_project_proto_v1_rgmii.tcl
+++ b/examples/ac701_proto_v1/create_project_proto_v1_rgmii.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2020, 2021 The Aerospace Corporation
+# Copyright 2019, 2020, 2021, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -43,3 +43,8 @@ set files_main [list \
 
 # Run the main script.
 source ../../project/vivado/shared_create.tcl
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin $target_top.bin

--- a/examples/ac701_proto_v1/create_project_proto_v1_sgmii.tcl
+++ b/examples/ac701_proto_v1/create_project_proto_v1_sgmii.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2020, 2021 The Aerospace Corporation
+# Copyright 2019, 2020, 2021, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -49,3 +49,8 @@ set files_main [list \
 
 # Run the main script.
 source ../../project/vivado/shared_create.tcl
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin $target_top.bin

--- a/examples/ac701_router/create_project_router_ac701.tcl
+++ b/examples/ac701_router/create_project_router_ac701.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2022 The Aerospace Corporation
+# Copyright 2019, 2022, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -257,3 +257,8 @@ set_msg_config -suppress -id {[DRC 23-20]}
 set wrapper [make_wrapper -files [get_files ${design_name}.bd] -top]
 add_files -norecurse $wrapper
 set_property "top" router_ac701_wrapper [get_filesets sources_1]
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin router_ac701_wrapper.bin

--- a/examples/arty_a7/create_project_arty_a7.tcl
+++ b/examples/arty_a7/create_project_arty_a7.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2020, 2021 The Aerospace Corporation
+# Copyright 2019, 2020, 2021, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -63,3 +63,8 @@ set files_main [list \
 
 # Run the main script.
 source ../../project/vivado/shared_create.tcl
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin $target_top.bin

--- a/examples/proto_v2/create_project_proto_v2.tcl
+++ b/examples/proto_v2/create_project_proto_v2.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019, 2020, 2021 The Aerospace Corporation
+# Copyright 2019, 2020, 2021, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -102,3 +102,8 @@ set files_main [list \
 
 # Run the main script.
 source ../../project/vivado/shared_create.tcl
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_bin $target_top.bin

--- a/examples/zed_converter/create_project_converter_zed.tcl
+++ b/examples/zed_converter/create_project_converter_zed.tcl
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------
-# Copyright 2019 The Aerospace Corporation
+# Copyright 2019, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -105,3 +105,8 @@ close_bd_design [get_bd_designs ps]
 
 # unset to avoid interference with future runs
 unset target_board
+
+# Execute the build and write out the .bin file.
+source ../../project/vivado/shared_build.tcl
+satcat5_launch_run
+satcat5_write_hdf $target_top.hdf

--- a/project/vivado/build_project.tcl
+++ b/project/vivado/build_project.tcl
@@ -1,4 +1,4 @@
-# Copyright 2019, 2022 The Aerospace Corporation
+# Copyright 2019, 2022, 2023 The Aerospace Corporation
 #
 # This file is part of SatCat5.
 #
@@ -49,9 +49,11 @@ satcat5_launch_run
 
 # If requested, also write out the .bit or .hdf file.
 # Note: OUT_NAME is set by the "create_project" or "shared_create" script.
+variable prev_dir [pwd]
 cd [get_property DIRECTORY [get_runs impl_1]]
 if {$CFGMEM_TYPE == "zynq"} {
     satcat5_write_hdf ${OUT_NAME}.hdf
 } elseif {$CFGMEM_TYPE == "cfgmem"} {
     satcat5_write_bin ${OUT_NAME}.bin $CFGMEM_INTERFACE $CFGMEM_SIZE
 }
+cd $prev_dir


### PR DESCRIPTION
Simplify build process and update the ARTY_A7 readme.

In relation to bug report here: https://github.com/the-aerospace-corporation/satcat5/issues/19

## Description
Move from a two-step process to a one-step process, to simplify instructions.

## How Has This Been Tested?
Passes internal Jenkins build on Linux systems.  Have also tested manually on Windows.  In all cases, the ARTY_A7 example build completes successfully.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
