### PR TITLE
Fix IP-core path handling in newer versions of Vivado.

### DIFF
--- a/project/vivado/ipcores/ipcore_shared.tcl
+++ b/project/vivado/ipcores/ipcore_shared.tcl
@@ -128,7 +128,7 @@ proc ipcore_add_file { src_pattern {folder src} } {
         # Copy the file to the IP folder.
         file copy -force "${src_file}" "${ip_dir}/${folder}"
         # Add to project using the new relative path.
-        set dst_file "${folder}/[file tail ${src_file}]"
+        set dst_file "${ip_dir}/${folder}/[file tail ${src_file}]"
         ipx::add_file "${dst_file}" $fg_syn
         ipx::add_file "${dst_file}" $fg_sim
         # Separate list of new files returned to user.


### PR DESCRIPTION
## Description
One line fix in ipcore_shared.tcl:
Old: `set dst_file "${folder}/[file tail ${src_file}]"`
New: `set dst_file "${ip_dir}/${folder}/[file tail ${src_file}]"`

## Motivation and Context
This should fix Issue #25.  It appears that newer versions of Vivado changed the handling of paths inside an IP-core.  I have mitigated this by using the full path in such cases.

## How Has This Been Tested?
Run "create_cfgbus_gpi.tcl" in various versions of Vivado.  Old works in 2019 only.  New works in 2019 and 2020.

Currently running the full test suite on the internal Jenkins.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
