### PR TITLE
ARP-cache metadata hotfix.

### DIFF
--- a/src/cpp/satcat5/ip_table.h
+++ b/src/cpp/satcat5/ip_table.h
@@ -153,8 +153,7 @@ namespace satcat5 {
             // Returns true if any records are updated.
             bool route_cache(
                 const satcat5::ip::Addr& gateway,
-                const satcat5::eth::MacAddr& dstmac,
-                u8 port = 0, u8 flags = 0);
+                const satcat5::eth::MacAddr& dstmac);
 
             // Remove a single static route.
             // Returns true if successful, false if no match is found.

--- a/src/cpp/satcat5/router2_dispatch.cc
+++ b/src/cpp/satcat5/router2_dispatch.cc
@@ -45,6 +45,11 @@ satcat5::eth::MacAddr Dispatch::macaddr() const {
     return m_local_iface ? m_local_iface->macaddr() : satcat5::eth::MACADDR_NONE;
 }
 
+void Dispatch::set_ipaddr(const satcat5::ip::Addr& addr) {
+    if (m_local_iface) m_local_iface->set_ipaddr(addr);
+    if (m_offload) m_offload->reconfigure();
+}
+
 unsigned Dispatch::deliver(satcat5::io::MultiPacket* packet) {
     // Attempt to read the Ethernet and partial IPv4 headers.
     SwitchPlugin::PacketMeta meta{};

--- a/src/cpp/satcat5/router2_dispatch.h
+++ b/src/cpp/satcat5/router2_dispatch.h
@@ -66,6 +66,7 @@ namespace satcat5 {
                 { return m_local_iface; }
             satcat5::ip::Addr ipaddr() const;
             satcat5::eth::MacAddr macaddr() const;
+            void set_ipaddr(const satcat5::ip::Addr& addr);
 
         protected:
             // Deferred forwarding needs privileged access.

--- a/src/cpp/satcat5/router2_offload.h
+++ b/src/cpp/satcat5/router2_offload.h
@@ -48,6 +48,11 @@ namespace satcat5 {
             //! Deliver a given packet to the hardware queue.
             void deliver(const satcat5::eth::SwitchPlugin::PacketMeta& meta);
 
+            //! Reload router IP address and MAC address.
+            //! The router2::Dispatch class calls this after any address change.
+            //! Return value is for internal use only and should be ignored.
+            u32 reconfigure();
+
             //! Mask indicating hardware-defined ports in the shutdown state.
             inline u32 link_shdn_hw()
                 { return m_ctrl->port_shdn; }
@@ -68,7 +73,6 @@ namespace satcat5 {
         protected:
             // Internal event-handlers.
             void irq_event() override;
-            u32 reconfigure();
 
             // Hardware register map:
             // TODO: Provide accessors for some of these hardware registers?

--- a/src/cpp/satcat5/router2_stack.h
+++ b/src/cpp/satcat5/router2_stack.h
@@ -66,6 +66,8 @@ namespace satcat5 {
                 { return m_ip.table(); }
             inline satcat5::udp::Dispatch* udp()
                 { return &m_udp; }
+            inline void set_ipaddr(const satcat5::ip::Addr& addr)
+                { return m_dispatch.set_ipaddr(addr); }
 
         protected:
             //! Constructor should only be called by the child class.


### PR DESCRIPTION
Hotfix for ARP-cache handling of router-related metadata.

## Description
Previously, the routing table's `route_cache` method accepted user-provided port and flag data for use with the router.  However, this metadata was not provided by ip::Dispatch when updating the ARP cache.  As a result, it creates new entries with default values (port = 0, flags = 0), which would cause outgoing packets to be dropped or misdirected.  Under this update, required metadata is populated automatically.

## Motivation and Context
Since this bug makes certain router/subnet configurations nearly unusable, this is a high-priority hotfix that should be deployed immediately.  Mirrors internal PR-515.

## How Has This Been Tested?
Usual battery of automated tests on the internal repo.
Have also run software unit tests on this hotfix specifically, to make sure it's not relying on other in-progress internal updates.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
