### PR TITLE
Fix control register mismatch for loading data into router2::Table.

### DIFF
--- a/sim/cpp/test_router2_table.cc
+++ b/sim/cpp/test_router2_table.cc
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2024 The Aerospace Corporation.
+// Copyright 2024-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 // Test cases for the routing table's mirror-to-hardware variant
@@ -11,8 +11,8 @@
 
 // Define register map (see "router2_common.vhd")
 static const unsigned CFG_DEVADDR   = 42;
-static const unsigned REG_CTRL      = 508;
-static const unsigned REG_DATA      = 509;
+static const unsigned REG_CTRL      = 509;
+static const unsigned REG_DATA      = 508;
 static const unsigned TABLE_SIZE    = 8;
 
 TEST_CASE("router2_table") {

--- a/src/cpp/satcat5/router2_table.cc
+++ b/src/cpp/satcat5/router2_table.cc
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2024 The Aerospace Corporation.
+// Copyright 2024-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 
@@ -10,8 +10,8 @@ using satcat5::ip::Route;
 using satcat5::router2::Table;
 
 // Register map defined in "router2_common.vhd"
-static constexpr unsigned REG_CTRL  = 508;
-static constexpr unsigned REG_DATA  = 509;
+static constexpr unsigned REG_CTRL  = 509;
+static constexpr unsigned REG_DATA  = 508;
 
 // Bit masks for the control register.
 static constexpr u32 MASK_BUSY      = (1u << 31);


### PR DESCRIPTION
Fix control register mismatch for loading data into router2::Table.

## Description
Fixed a mismatch in two ConfigBus register addresses.

Specifically, the VHDL routing table uses two registers, one for control and one for data. The VHDL had these at address 509 and 508, respectively. The C++ had it at 508 and 509. This led to corrupt data being loaded into the table, resulting in nonsense MAC addresses observed during testing.

## Motivation and Context
Hotfix matches internal PR 527.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
