### PR TITLE
Hotfix for Arty-100T

### DIFF
--- a/examples/arty_managed/arty_managed_synth.xdc
+++ b/examples/arty_managed/arty_managed_synth.xdc
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Aerospace Corporation.
+# Copyright 2021-2025 The Aerospace Corporation.
 # This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 
 # Synthesis constraints for arty_managed
@@ -52,6 +52,16 @@ set_property PACKAGE_PIN D3     [get_ports {pmod4[1]}];
 set_property PACKAGE_PIN F4     [get_ports {pmod4[2]}];
 set_property PACKAGE_PIN F3     [get_ports {pmod4[3]}];
 
+# Configuration buttons and switches
+set_property PACKAGE_PIN A8     [get_ports {cfg_sw[0]}];    # SW0
+set_property PACKAGE_PIN C11    [get_ports {cfg_sw[1]}];    # SW1
+set_property PACKAGE_PIN C10    [get_ports {cfg_sw[2]}];    # SW2
+set_property PACKAGE_PIN A10    [get_ports {cfg_sw[3]}];    # SW3
+set_property PACKAGE_PIN D9     [get_ports {cfg_sw[4]}];    # BTN0
+set_property PACKAGE_PIN C9     [get_ports {cfg_sw[5]}];    # BTN1
+set_property PACKAGE_PIN B9     [get_ports {cfg_sw[6]}];    # BTN2
+set_property PACKAGE_PIN B8     [get_ports {cfg_sw[7]}];    # BTN3
+
 # I2C interface (J3)
 set_property PACKAGE_PIN L18    [get_ports i2c_sck];        # CK_SCL
 set_property PACKAGE_PIN M18    [get_ports i2c_sda];        # CK_SDA
@@ -81,8 +91,8 @@ set_property PACKAGE_PIN G1     [get_ports spi_sdi];        # CK_MISO
 set_property PACKAGE_PIN H1     [get_ports spi_sdo];        # CK_MOSI
 
 # USB-UART Interface
-set_property PACKAGE_PIN D10    [get_ports uart_txd];
-set_property PACKAGE_PIN A9     [get_ports uart_rxd];
+set_property PACKAGE_PIN D10    [get_ports uart_txd];       # UART_RXD_OUT
+set_property PACKAGE_PIN A9     [get_ports uart_rxd];       # UART_TXD_IN
 
 # Text-mode LCD on ChipKit header
 set_property PACKAGE_PIN V15    [get_ports {text_lcd_db[0]}];   # CK_IO0
@@ -104,6 +114,7 @@ set_property PACKAGE_PIN R17    [get_ports tft_sdo];    # CK_IO12
 ### Set all voltages and signaling standards
 
 # All I/O pins at 3.3V
+set_property IOSTANDARD LVCMOS33 [get_ports cfg_sw*];
 set_property IOSTANDARD LVCMOS33 [get_ports ext_clk100];
 set_property IOSTANDARD LVCMOS33 [get_ports ext_reset_n];
 set_property IOSTANDARD LVCMOS33 [get_ports i2c*];

--- a/examples/arty_managed/sdk_src/arty_devices.h
+++ b/examples/arty_managed/sdk_src/arty_devices.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2021-2024 The Aerospace Corporation.
+// Copyright 2021-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 // Define hardware constants relating to the "Arty-Managed" design.
@@ -25,6 +25,7 @@ static const unsigned DEVADDR_TIMER     = 9;    // Timer functions
 static const unsigned DEVADDR_I2C       = 10;   // I2C controller
 static const unsigned DEVADDR_SPI       = 11;   // SPI controller (J6)
 static const unsigned DEVADDR_TFT       = 12;   // SPI controller (TFT)
+static const unsigned DEVADDR_CFGSW     = 13;   // Buttons and switches
 
 // Arty's RMII Ethernet PHY address for MDIO queries.
 static const unsigned RMII_PHYADDR      = 1;

--- a/examples/arty_managed/sdk_src/main.cc
+++ b/examples/arty_managed/sdk_src/main.cc
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2021-2024 The Aerospace Corporation.
+// Copyright 2021-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 // Microblaze software top-level for the "Arty Managed" example design
@@ -9,6 +9,7 @@
 #include <hal_ublaze/uart16550.h>
 #include <satcat5/build_date.h>
 #include <satcat5/cfgbus_core.h>
+#include <satcat5/cfgbus_gpio.h>
 #include <satcat5/cfgbus_mdio.h>
 #include <satcat5/cfgbus_led.h>
 #include <satcat5/cfgbus_spi.h>
@@ -63,6 +64,7 @@ satcat5::port::SerialAuto   pmod3           (&cfgbus, DEVADDR_PMOD3);
 satcat5::port::SerialAuto   pmod4           (&cfgbus, DEVADDR_PMOD4);
 satcat5::eth::SwitchConfig  eth_switch      (&cfgbus, DEVADDR_SWCORE);
 satcat5::cfg::NetworkStats  traffic_stats   (&cfgbus, DEVADDR_TRAFFIC);
+satcat5::cfg::GpiRegister   cfg_sw          (&cfgbus, DEVADDR_CFGSW, 0);
 satcat5::cfg::Mdio          eth_mdio        (&cfgbus, DEVADDR_MDIO);
 satcat5::cfg::Spi           spi_j6          (&cfgbus, DEVADDR_SPI);
 satcat5::cfg::Spi           spi_tft         (&cfgbus, DEVADDR_TFT);


### PR DESCRIPTION
The "arty_managed" example design targets the Arty-35T (default) and the Arty-100T.  User reported a bug by email, indicating that the 100T variant was no longer able to build.  This hotfix corrects that bug.

## Description
Root cause was a TCL script we added to disable certain features on the 35T, since there's not enough slices.  As a result, certain block-design nets are created early on the 100T variant.  Due to the way Vivado handles connections to unnamed nets, this caused problems later in the script.  Correction was to provide net-names, allowing the Vivado to correctly identify all connections as part of the same net.

On the internal repo, there was some other recent work to add the buttons and switches available on that board.  Rather than trying to separate things, I'm mirroring that to Github to keep everything in sync.  This corresponds to internal PR 563 and 566.

## Motivation and Context
User reported a bug by email, so there is no open issue.

## How Has This Been Tested?
Manual build of both 35T and 100T variants completed successfully.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
