### PR TITLE
Hotfix for Arty-managed design.

### DIFF
--- a/examples/arty_a7/switch_arty_a7_synth.xdc
+++ b/examples/arty_a7/switch_arty_a7_synth.xdc
@@ -1,4 +1,4 @@
-# Copyright 2021 The Aerospace Corporation.
+# Copyright 2021-2025 The Aerospace Corporation.
 # This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 
 # Synthesis constraints for switch_top_arty_a7
@@ -20,9 +20,10 @@ set_property PACKAGE_PIN H15 [get_ports rmii_txen]
 set_property PACKAGE_PIN H14 [get_ports {rmii_txd[0]}]
 set_property PACKAGE_PIN J14 [get_ports {rmii_txd[1]}]
 set_property PACKAGE_PIN G18 [get_ports rmii_refclk]
-set_property PACKAGE_PIN G16 [get_ports rmii_mode]
+set_property PACKAGE_PIN D17 [get_ports {rmii_mode[0]}]; # Bootstrap PHYADDR = 1
+set_property PACKAGE_PIN G16 [get_ports {rmii_mode[1]}]; # Bootstrap RMII mode
 set_property PACKAGE_PIN C16 [get_ports rmii_resetn]
-#set_property PACKAGE_PIN B8     [get_ports { ETH_INTN }];      #IO_L12P_T1_MRCC_16 Sch=eth_intn TODO: We don't care about interrupts
+set_property PULLDOWN TRUE   [get_ports rmii_rx*];       # Bootstrap PHYADDR = 1
 
 ## ChipKit SPI = EoS-SPI0 (FPGA is slave / peripheral)
 ## Pin 1/2/3/4 = CSb, SDI(MOSI), SDO(MISO), SCK

--- a/examples/arty_a7/switch_top_arty_a7_rmii.vhd
+++ b/examples/arty_a7/switch_top_arty_a7_rmii.vhd
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------
--- Copyright 2021-2023 The Aerospace Corporation.
+-- Copyright 2021-2025 The Aerospace Corporation.
 -- This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 --------------------------------------------------------------------------
 --
@@ -32,7 +32,7 @@ entity switch_top_arty_a7_rmii is
     rmii_rxd    : in    std_logic_vector(1 downto 0);
     rmii_rxen   : in    std_logic;
     rmii_rxer   : in    std_logic;
-    rmii_mode   : out   std_logic; -- 1 for RMII, 0 for MII
+    rmii_mode   : out   std_logic_vector(1 downto 0);
     rmii_refclk : out   std_logic; -- 50 MHz reference from clkgen
     rmii_resetn : out   std_logic; -- PHY reset#
 
@@ -102,7 +102,7 @@ u_clkbuf : BUFG
     I   => ref_clk100,
     O   => clk_100);
 
-rmii_mode   <= '1';
+rmii_mode   <= "11";    -- Force RMII mode with PHYADDR = 1
 ext_reset_p <= not ext_reset_n;
 rmii_resetn <= not rmii_reset_p;
 

--- a/examples/arty_managed/arty_managed_synth.xdc
+++ b/examples/arty_managed/arty_managed_synth.xdc
@@ -23,8 +23,10 @@ set_property PACKAGE_PIN H15    [get_ports rmii_tx_en];
 set_property PACKAGE_PIN H14    [get_ports {rmii_txd[0]}];
 set_property PACKAGE_PIN J14    [get_ports {rmii_txd[1]}];
 set_property PACKAGE_PIN G18    [get_ports rmii_clkout];    # 50 MHz clock reference
-set_property PACKAGE_PIN G16    [get_ports rmii_mode];      # Bootstrap to RMII mode
+set_property PACKAGE_PIN D17    [get_ports {rmii_mode[0]}]; # Bootstrap PHYADDR = 1
+set_property PACKAGE_PIN G16    [get_ports {rmii_mode[1]}]; # Bootstrap RMII mode
 set_property PACKAGE_PIN C16    [get_ports rmii_resetn];
+set_property PULLDOWN TRUE      [get_ports rmii_rx*];       # Bootstrap PHYADDR = 1
 
 # PMOD JA = EoS-PMOD1
 # Pin 1/2/3/4 = RTSb, RXD, TXD, CTSb = Out, In, Out, In wrt USB-UART

--- a/examples/arty_managed/create_vivado.tcl
+++ b/examples/arty_managed/create_vivado.tcl
@@ -76,7 +76,7 @@ set uart_rxd [ create_bd_port -dir I uart_rxd ]
 set uart_txd [ create_bd_port -dir O uart_txd ]
 set rmii [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:rmii_rtl:1.0 rmii ]
 set rmii_clkout [ create_bd_port -dir O rmii_clkout ]
-set rmii_mode [ create_bd_port -dir O rmii_mode ]
+set rmii_mode [ create_bd_port -dir O -from 1 -to 0 rmii_mode ]
 set rmii_resetn [ create_bd_port -dir O rmii_resetn ]
 set mdio_clk [ create_bd_port -dir O mdio_clk ]
 set mdio_data [ create_bd_port -dir IO mdio_data ]
@@ -346,7 +346,14 @@ set_property -dict [list \
 
 set port_adapter_0 [ create_bd_cell -type ip -vlnv aero.org:satcat5:port_adapter port_adapter_0 ]
 set rmii_mode_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant rmii_mode_0 ]
+set_property -dict [ list \
+    CONFIG.CONST_WIDTH {2} \
+    CONFIG.CONST_VAL {3} \
+] $rmii_mode_0
 set rmii_reset_0 [ create_bd_cell -type ip -vlnv aero.org:satcat5:reset_hold rmii_reset_0 ]
+set_property -dict [ list \
+    CONFIG.RESET_HOLD {1000000} \
+] $rmii_reset_0
 set port_rmii_0 [ create_bd_cell -type ip -vlnv aero.org:satcat5:port_rmii port_rmii_0 ]
 set_property -dict [ list \
     CONFIG.MODE_CLKOUT {true} \

--- a/sim/cpp/test_ip_ping.cc
+++ b/sim/cpp/test_ip_ping.cc
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2022-2024 The Aerospace Corporation.
+// Copyright 2022-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 // Test cases for Ping utilities
@@ -70,7 +70,7 @@ TEST_CASE("Ping") {
     SECTION("icmp-badip") {
         // Attempt to ping a nonexistent address.
         net_a.m_ping.ping(IP_C, 2);
-        xlink.timer.sim_wait(3500);   // Attempt ARP 3 times then abort
+        xlink.timer.sim_wait(5500);   // Attempt ARP 5 times then abort
         CHECK(log.contains("Gateway unreachable"));
     }
 

--- a/src/cpp/satcat5/polling.h
+++ b/src/cpp/satcat5/polling.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2021-2024 The Aerospace Corporation.
+// Copyright 2021-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 //! \file
@@ -166,7 +166,7 @@ namespace satcat5 {
             //! Get the system time reference, if one is set.
             //! Note: The SATCAT5_CLOCK macro is an alias for
             //!  satcat5::poll::timekeeper.get_clock().
-            satcat5::util::TimeRef* get_clock() { return m_clock; }
+            satcat5::util::TimeRef* get_clock() const;
 
             //! Has a system time reference been provided?
             bool clock_ready() const;
@@ -186,7 +186,6 @@ namespace satcat5 {
 
         protected:
             void poll_demand() override;
-            satcat5::util::TimeRef* m_clock;
             satcat5::util::TimeVal m_tref;
         };
 

--- a/src/cpp/satcat5/timeref.h
+++ b/src/cpp/satcat5/timeref.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////
-// Copyright 2021-2024 The Aerospace Corporation.
+// Copyright 2021-2025 The Aerospace Corporation.
 // This file is a part of SatCat5, licensed under CERN-OHL-W v2 or later.
 //////////////////////////////////////////////////////////////////////////
 //! \file
@@ -189,7 +189,7 @@ namespace satcat5 {
         //! Placeholder used if no timer is available.
         class NullTimer : public satcat5::util::TimeRef {
         public:
-            NullTimer() : TimeRef(1) {}
+            constexpr NullTimer() : TimeRef(1) {}
             u32 raw() override {return 0;}
         };
 


### PR DESCRIPTION
Hotfixes for the Arty-Managed example design.

## Description
A user reported that the "arty_managed" example design is non-functional (i.e,. LEDs do not animate, no response to ping).  Root-cause was traced to a race-condition when initializing certain global variables, which was causing most software timers to fail completely.  During that investigation, I also found and corrected an unrelated bug in bootstrapping the RMII Ethernet PHY on that board.

## Motivation and Context
This hotfix mirrors internal PRs 563, 566, and 568.

## How Has This Been Tested?
All Jenkins tests completed, plus benchtop testing with an Arty-35T.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document and signed a CLA, if applicable.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
